### PR TITLE
Add minimal MMPI-2 web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # mmpi-2
+
+This repository contains a minimal web-based demo for presenting MMPI-2 style questions and calculating simple category scores.
+
+## Running the demo
+
+```sh
+node server/index.js
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in a browser.
+
+## Converting from Excel
+
+If you have an Excel file of questions (columns: `ID`, `Question`, `Category`), place it at `data/questions.xlsx` and run:
+
+```sh
+node scripts/convert.js
+```
+
+This requires the optional `xlsx` package to be installed. The script will output `data/questions.json` used by the server.
+
+## Disclaimer
+
+This project is for demonstration purposes only and does not replace professional psychological evaluation.

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "text": "I enjoy social gatherings", "category": "Si"},
+  {"id": 2, "text": "I often feel blue", "category": "D"},
+  {"id": 3, "text": "I like mechanical magazines", "category": "Hs"}
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mmpi-2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>MMPI-2 Demo</title>
+</head>
+<body>
+  <h1>MMPI-2 Demo</h1>
+  <form id="testForm">
+    <div id="questions"></div>
+    <button type="submit">Submit</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    fetch('/questions')
+      .then(res => res.json())
+      .then(qs => {
+        const container = document.getElementById('questions');
+        qs.forEach(q => {
+          const div = document.createElement('div');
+          div.innerHTML = `<p>${q.text}</p>
+            <label><input type="radio" name="q${q.id}" value="true">True</label>
+            <label><input type="radio" name="q${q.id}" value="false">False</label>`;
+          container.appendChild(div);
+        });
+      });
+
+    document.getElementById('testForm').addEventListener('submit', function (e) {
+      e.preventDefault();
+      const formData = new FormData(this);
+      const answers = {};
+      for (const [key, value] of formData.entries()) {
+        const id = key.replace('q', '');
+        answers[id] = value === 'true';
+      }
+      fetch('/answers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(answers)
+      })
+        .then(res => res.json())
+        .then(result => {
+          document.getElementById('result').textContent = JSON.stringify(result, null, 2);
+        });
+    });
+  </script>
+</body>
+</html>

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -1,0 +1,16 @@
+// This script converts an Excel file to JSON.
+// Requires the 'xlsx' package (npm install xlsx).
+
+const fs = require('fs');
+const xlsx = require('xlsx');
+
+const workbook = xlsx.readFile(process.argv[2] || 'data/questions.xlsx');
+const sheet = workbook.Sheets[workbook.SheetNames[0]];
+const rows = xlsx.utils.sheet_to_json(sheet);
+const formatted = rows.map((row, idx) => ({
+  id: row.ID || idx + 1,
+  text: row.Question,
+  category: row.Category
+}));
+fs.writeFileSync('data/questions.json', JSON.stringify(formatted, null, 2));
+console.log('Saved to data/questions.json');

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,56 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const questionsPath = path.join(__dirname, '../data/questions.json');
+const questions = JSON.parse(fs.readFileSync(questionsPath, 'utf8'));
+
+function handleRequest(req, res) {
+  if (req.method === 'GET' && req.url === '/questions') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(questions));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/answers') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const answers = JSON.parse(body || '{}');
+        const scores = {};
+        for (const q of questions) {
+          const ans = answers[q.id];
+          if (typeof ans === 'boolean') {
+            if (ans) {
+              scores[q.category] = (scores[q.category] || 0) + 1;
+            }
+          }
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ scores }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+    const indexPath = path.join(__dirname, '../public/index.html');
+    fs.createReadStream(indexPath).pipe(res);
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+}
+
+const server = http.createServer(handleRequest);
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement simple HTTP server to serve questions and score answers
- add browser page to present questions and post responses
- document running the demo and converting Excel data

## Testing
- `node server/index.js &`
- `curl -s http://localhost:3000/questions`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"1":true,"2":false,"3":true}' http://localhost:3000/answers`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4540f21688323898562e56a009efe